### PR TITLE
Block Placement Preview

### DIFF
--- a/super-cool-game/Assets/Scenes/playground.unity
+++ b/super-cool-game/Assets/Scenes/playground.unity
@@ -791,11 +791,11 @@ RectTransform:
   m_Father: {fileID: 765885782}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -110, y: -227.5}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 160, y: 30}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0, y: 1}
 --- !u!114 &1489450359
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Block z-index is bugged (they are rendered after the player) but it's going to be fixed in the PR #17 
Currently, the preview has to be toggled in _Playground.unity > GameManager > Building Controller (Script) > Is Building set to True_