### PR TITLE
Movement rework

### DIFF
--- a/super-cool-game/Assets/Prefabs/NetworkPlayer.prefab
+++ b/super-cool-game/Assets/Prefabs/NetworkPlayer.prefab
@@ -9,51 +9,77 @@ Prefab:
     m_Modifications: []
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 0}
-  m_RootGameObject: {fileID: 1776720557226012}
+  m_RootGameObject: {fileID: 1978361185441664}
   m_IsPrefabAsset: 1
---- !u!1 &1776720557226012
+--- !u!1 &1582488877775548
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 4496363223133698}
-  - component: {fileID: 212157287816818246}
-  - component: {fileID: 50450075659912566}
-  - component: {fileID: 61577621002967886}
-  - component: {fileID: 68544614564757800}
-  - component: {fileID: 114170011091315696}
-  - component: {fileID: 114768846942360522}
-  - component: {fileID: 114600772715152986}
-  - component: {fileID: 114632723430306198}
-  m_Layer: 9
-  m_Name: Player
-  m_TagString: Player
+  - component: {fileID: 4963924531369526}
+  - component: {fileID: 50042681929689392}
+  - component: {fileID: 61375513134997246}
+  - component: {fileID: 68257435588890064}
+  m_Layer: 0
+  m_Name: RigidBody
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &4496363223133698
+--- !u!1 &1978361185441664
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4913606454108088}
+  - component: {fileID: 212907277568099534}
+  - component: {fileID: 114075231313030982}
+  m_Layer: 0
+  m_Name: NetworkPlayer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4913606454108088
 Transform:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1776720557226012}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_GameObject: {fileID: 1978361185441664}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 2, z: 0}
   m_LocalScale: {x: 1, y: 1.6, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 4963924531369526}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!50 &50450075659912566
+--- !u!4 &4963924531369526
+Transform:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1582488877775548}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4913606454108088}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!50 &50042681929689392
 Rigidbody2D:
   serializedVersion: 4
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1776720557226012}
+  m_GameObject: {fileID: 1582488877775548}
   m_BodyType: 0
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
@@ -67,12 +93,12 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 4
---- !u!61 &61577621002967886
+--- !u!61 &61375513134997246
 BoxCollider2D:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1776720557226012}
+  m_GameObject: {fileID: 1582488877775548}
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 6200000, guid: fb2920345b08e3345b9abfad726b4f9c, type: 2}
@@ -92,12 +118,12 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.64, y: 0.64}
   m_EdgeRadius: 0
---- !u!68 &68544614564757800
+--- !u!68 &68257435588890064
 EdgeCollider2D:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1776720557226012}
+  m_GameObject: {fileID: 1582488877775548}
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
@@ -109,59 +135,24 @@ EdgeCollider2D:
   m_Points:
   - {x: -0.3, y: 0}
   - {x: 0.3, y: 0}
---- !u!114 &114170011091315696
+--- !u!114 &114075231313030982
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1776720557226012}
+  m_GameObject: {fileID: 1978361185441664}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a75f10567b7b6864489e236cf9bd44fa, type: 3}
+  m_Script: {fileID: 11500000, guid: a42c580db32be524b9e6969ef8a28be3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &114600772715152986
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1776720557226012}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 98852ab996a1ef54bb8bc3836b0092b5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  ERROR_THRESHOLD: 0.2
---- !u!114 &114632723430306198
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1776720557226012}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: edfa944f025a7ca4c99650f4b1e3062f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &114768846942360522
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1776720557226012}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 66e6ade5b2fe9594c9dfde4bce5ddc6e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  speed: 4
-  jumpHeight: 7
---- !u!212 &212157287816818246
+  lerpAmount: 0.3
+--- !u!212 &212907277568099534
 SpriteRenderer:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1776720557226012}
+  m_GameObject: {fileID: 1978361185441664}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0

--- a/super-cool-game/Assets/Prefabs/NetworkPlayer.prefab.meta
+++ b/super-cool-game/Assets/Prefabs/NetworkPlayer.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a0c1bd6e94072cf45b4fbd5b96cc655f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/super-cool-game/Assets/Scenes/multiplayer.unity
+++ b/super-cool-game/Assets/Scenes/multiplayer.unity
@@ -434,10 +434,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3171485e15af9ed47b00ae2f1c2a40ec, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  playerPrefab: {fileID: 1156296963878952, guid: f513314412cfff84fad74073ff1aceb5,
+  playerPrefab: {fileID: 1776720557226012, guid: f513314412cfff84fad74073ff1aceb5,
+    type: 2}
+  networkPlayerPrefab: {fileID: 1978361185441664, guid: a0c1bd6e94072cf45b4fbd5b96cc655f,
     type: 2}
   cam: {fileID: 1000315785}
-  myPort: 0
 --- !u!1 &2015692979
 GameObject:
   m_ObjectHideFlags: 0
@@ -466,6 +467,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   showDebugGrid: 0
+  isBuilding: 0
   blockWidth: 4
   b_gridHeight: 30
   b_gridTeamWidth: 3

--- a/super-cool-game/Assets/Scenes/playground.unity
+++ b/super-cool-game/Assets/Scenes/playground.unity
@@ -350,7 +350,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &534973518
 GameObject:
@@ -380,6 +380,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   showDebugGrid: 1
+  isBuilding: 0
   blockWidth: 4
   b_gridHeight: 30
   b_gridTeamWidth: 3
@@ -400,7 +401,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &705295524
 GameObject:
@@ -576,189 +577,27 @@ RectTransform:
   m_Children:
   - {fileID: 1489450358}
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
---- !u!1 &1363605354
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1363605358}
-  - component: {fileID: 1363605360}
-  - component: {fileID: 1363605361}
-  - component: {fileID: 1363605359}
-  - component: {fileID: 1363605357}
-  - component: {fileID: 1363605356}
-  - component: {fileID: 1363605355}
-  - component: {fileID: 1363605362}
-  m_Layer: 0
-  m_Name: Player
-  m_TagString: Player
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!61 &1363605355
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1363605354}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 6200000, guid: fb2920345b08e3345b9abfad726b4f9c, type: 2}
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 0.64, y: 0.64}
-    newSize: {x: 0.64, y: 0.64}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 0.64, y: 0.64}
-  m_EdgeRadius: 0
---- !u!50 &1363605356
-Rigidbody2D:
-  serializedVersion: 4
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1363605354}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDrag: 0
-  m_AngularDrag: 0
-  m_GravityScale: 0
-  m_Material: {fileID: 6200000, guid: fb2920345b08e3345b9abfad726b4f9c, type: 2}
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 4
---- !u!212 &1363605357
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1363605354}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 4294967295
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: a406998286053404c965cc33edb281cb, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 0.64, y: 0.64}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!4 &1363605358
+--- !u!4 &1413624836
 Transform:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 4496363223133698, guid: f513314412cfff84fad74073ff1aceb5,
+    type: 2}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1363605354}
+  m_GameObject: {fileID: 1915148697}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 2, z: 0}
   m_LocalScale: {x: 1, y: 1.6, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1363605359
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1363605354}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a75f10567b7b6864489e236cf9bd44fa, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1363605360
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1363605354}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 98852ab996a1ef54bb8bc3836b0092b5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1363605361
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1363605354}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 66e6ade5b2fe9594c9dfde4bce5ddc6e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!68 &1363605362
-EdgeCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1363605354}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: -0.32}
-  m_EdgeRadius: 0
-  m_Points:
-  - {x: -0.32, y: 0}
-  - {x: 0.32, y: 0}
 --- !u!1 &1489450357
 GameObject:
   m_ObjectHideFlags: 0
@@ -911,7 +750,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1.69, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1854689415
 MonoBehaviour:
@@ -924,7 +763,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4b9b99ed2793054419f3e24678c13220, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  target: {fileID: 1363605358}
+  target: {fileID: 1413624836}
   smoothSpeed: 0.125
   offset: {x: 0, y: 0, z: -4}
 --- !u!81 &1854689416
@@ -974,3 +813,177 @@ Camera:
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
+--- !u!1 &1915148697
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 1776720557226012, guid: f513314412cfff84fad74073ff1aceb5,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1413624836}
+  - component: {fileID: 1915148704}
+  - component: {fileID: 1915148703}
+  - component: {fileID: 1915148702}
+  - component: {fileID: 1915148701}
+  - component: {fileID: 1915148700}
+  - component: {fileID: 1915148699}
+  - component: {fileID: 1915148698}
+  m_Layer: 9
+  m_Name: Player
+  m_TagString: Player
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1915148698
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 114600772715152986, guid: f513314412cfff84fad74073ff1aceb5,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1915148697}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 98852ab996a1ef54bb8bc3836b0092b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ERROR_THRESHOLD: 0.2
+--- !u!114 &1915148699
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 114768846942360522, guid: f513314412cfff84fad74073ff1aceb5,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1915148697}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 66e6ade5b2fe9594c9dfde4bce5ddc6e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  speed: 4
+  jumpHeight: 7
+--- !u!114 &1915148700
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 114170011091315696, guid: f513314412cfff84fad74073ff1aceb5,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1915148697}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a75f10567b7b6864489e236cf9bd44fa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!68 &1915148701
+EdgeCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 68544614564757800, guid: f513314412cfff84fad74073ff1aceb5,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1915148697}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: -0.32}
+  m_EdgeRadius: 0
+  m_Points:
+  - {x: -0.3, y: 0}
+  - {x: 0.3, y: 0}
+--- !u!61 &1915148702
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 61577621002967886, guid: f513314412cfff84fad74073ff1aceb5,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1915148697}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 6200000, guid: fb2920345b08e3345b9abfad726b4f9c, type: 2}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 0.64, y: 0.64}
+    newSize: {x: 0.64, y: 0.64}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.64, y: 0.64}
+  m_EdgeRadius: 0
+--- !u!50 &1915148703
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 50450075659912566, guid: f513314412cfff84fad74073ff1aceb5,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1915148697}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0
+  m_GravityScale: 0
+  m_Material: {fileID: 6200000, guid: fb2920345b08e3345b9abfad726b4f9c, type: 2}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 4
+--- !u!212 &1915148704
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 212157287816818246, guid: f513314412cfff84fad74073ff1aceb5,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1915148697}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: a406998286053404c965cc33edb281cb, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.64, y: 0.64}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0

--- a/super-cool-game/Assets/Scripts/Multiplayer/MultiplayerGame.cs
+++ b/super-cool-game/Assets/Scripts/Multiplayer/MultiplayerGame.cs
@@ -1,54 +1,38 @@
 ﻿using SuperCoolNetwork;
 using System;
+using System.Collections;
 using UnityEngine;
 
 public class MultiplayerGame : MonoBehaviour {
     public GameObject playerPrefab;
+    public GameObject networkPlayerPrefab;
     public GameObject cam;
+
+    private Queue setPosQueue = new Queue();
 
     // Use this for initialization
     void Start() {
         
     }
 
-    // FixedUpdate is called at a constant rate
-    void FixedUpdate() {
-        // Only process 1 SetPos command per FixedUpdate
-        bool processedPos = false;
-        int skipCommands = 0;
-
-        while (NetCode.CmdQueue.Count - skipCommands > 0) {
-            lock (NetCode.CmdQueue.SyncRoot) {
+    private void Update() {
+        lock (NetCode.CmdQueue.SyncRoot) {
+            while (NetCode.CmdQueue.Count > 0) {
                 byte[] buffer = (byte[])NetCode.CmdQueue.Dequeue();
 
                 // Shared variables for the following cases
                 int uid;
 
                 switch (buffer[0]) {
+                    case (byte)OpCode.SetPos:
+                        setPosQueue.Enqueue(buffer);
+                        break;
+
                     case (byte)OpCode.Spawn:
                         uid = BitConverter.ToUInt16(buffer, 1);
                         var spawnX = BitConverter.ToSingle(buffer, 3);
                         var spawnY = BitConverter.ToSingle(buffer, 7);
                         Spawn(uid, new Vector2(spawnX, spawnY));
-                        break;
-
-                    case (byte)OpCode.SetPos:
-                        // Only process 1 SetPos command per FixedUpdate
-                        if (processedPos) {
-                            NetCode.CmdQueue.Enqueue(buffer);
-                            skipCommands++;
-                            break;
-                        }
-
-                        int n = (buffer.Length - 1) / 10;
-                        for (int i = 0; i < n; i++) {
-                            uid = BitConverter.ToUInt16(buffer, 1 + i * 10);
-                            Vector2 pos = new Vector2(
-                                BitConverter.ToSingle(buffer, 3 + i * 10),
-                                BitConverter.ToSingle(buffer, 7 + i * 10));
-                            MovePlayer(uid, pos);
-                        }
-                        processedPos = true;
                         break;
 
                     case (byte)OpCode.Disconnect:
@@ -65,26 +49,46 @@ public class MultiplayerGame : MonoBehaviour {
         }
     }
 
-    private void Spawn(int uid, Vector2 pos) {
-        var playerSpawn = Instantiate(playerPrefab, pos, Quaternion.identity);
-        playerSpawn.name = uid.ToString();
-        if (uid == NetCode.ClientPort) {
-            // It's me, attach input and camera
-            playerSpawn.AddComponent<PlayerInput>();
-            playerSpawn.AddComponent<PlayerController>();
-            playerSpawn.AddComponent<Ping>();
-            cam.GetComponent<PlayerCamera>().target = playerSpawn.transform;
+    // FixedUpdate is called at a constant rate
+    void FixedUpdate() {
+        if (setPosQueue.Count > 0) {
+            byte[] buffer = (byte[])setPosQueue.Dequeue();
+
+            // Shared variables for the following cases
+            int uid;
+            const int message_size_per_player = 2 + 4 + 4 + 4 + 4;
+            int n = (buffer.Length - 1) / message_size_per_player;
+            for (int i = 0; i < n; i++) {
+                uid = BitConverter.ToUInt16(buffer, 1 + i * message_size_per_player);
+                Vector2 pos = new Vector2(
+                    BitConverter.ToSingle(buffer, 3 + i * message_size_per_player),
+                    BitConverter.ToSingle(buffer, 7 + i * message_size_per_player));
+                Vector2 vel = new Vector2(
+                    BitConverter.ToSingle(buffer, 11 + i * message_size_per_player),
+                    BitConverter.ToSingle(buffer, 15 + i * message_size_per_player));
+                MovePlayer(uid, pos, vel);
+            }
         }
     }
 
-    private void MovePlayer(int uid, Vector2 pos) {
-        GameObject player = GameObject.Find(uid.ToString());
-        Rigidbody2D rb = player.GetComponent<Rigidbody2D>();
-        PlayerMovement pm = player.GetComponent<PlayerMovement>();
+    private void Spawn(int uid, Vector2 pos) {
+        GameObject playerSpawn;
+        if (uid == NetCode.ClientPort) {
+            playerSpawn = Instantiate(playerPrefab, pos, Quaternion.identity);
+            cam.GetComponent<PlayerCamera>().target = playerSpawn.transform;
+        } else {
+            playerSpawn = Instantiate(networkPlayerPrefab, pos, Quaternion.identity);
+        }
+        playerSpawn.name = uid.ToString();
+    }
 
-        Vector2 delta = pos - rb.position;
-        pm.MoveX(delta.x / Time.fixedDeltaTime);
-        pm.MoveY(delta.y / Time.fixedDeltaTime);
+    private void MovePlayer(int uid, Vector2 pos, Vector2 vel) {
+        GameObject player = GameObject.Find(uid.ToString());
+        if (uid == NetCode.ClientPort) {
+            player.GetComponent<PlayerMovement>().AuthoritativeMove(pos, vel);
+        } else {
+            player.GetComponent<NetworkPlayer>().Move(pos, vel);
+        }
     }
 
     private void OnDestroy() {

--- a/super-cool-game/Assets/Scripts/Player/NetworkPlayer.cs
+++ b/super-cool-game/Assets/Scripts/Player/NetworkPlayer.cs
@@ -1,0 +1,32 @@
+﻿using UnityEngine;
+
+public class NetworkPlayer : MonoBehaviour {
+    /*
+     * This script handles the movement for the player objects
+     * that are not controlled by this client.
+     * Sets the rigidbody position, and lerps the mesh to it
+     */
+
+    public float lerpAmount = 0.1f;
+    private Rigidbody2D rb;
+
+	// Use this for initialization
+	void Start () {
+        rb = gameObject.GetComponentInChildren<Rigidbody2D>();
+	}
+	
+	// Update is called once per frame
+	void Update () {
+        // Save rigidbody absolute position
+        var tmp = rb.gameObject.transform.position;
+        // Compute lerping
+        gameObject.transform.position = Vector2.Lerp(gameObject.transform.position, rb.position, lerpAmount);
+        // Restore rigidbody position
+        rb.gameObject.transform.position = tmp;
+	}
+
+    public void Move(Vector2 pos, Vector2 vel) {
+        rb.position = pos;
+        rb.velocity = vel;
+    }
+}

--- a/super-cool-game/Assets/Scripts/Player/NetworkPlayer.cs.meta
+++ b/super-cool-game/Assets/Scripts/Player/NetworkPlayer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a42c580db32be524b9e6969ef8a28be3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/super-cool-game/Assets/Scripts/Player/PlayerController.cs
+++ b/super-cool-game/Assets/Scripts/Player/PlayerController.cs
@@ -4,35 +4,37 @@ using UnityEngine;
 
 // This is gonna be used to send multiplayer commands too.
 public class PlayerController : MonoBehaviour {
-    /* Translates inputs from PlayerInput into move commands
+    /* 
+     * Translates inputs from PlayerInput into move commands
      * to be sento to PlayerMovement and over the Network
      */
      
     private PlayerMovement pm;
-    private float speed = 4.0f;
-    private float jumpHeight = 7.0f;
+    public float speed = 4.0f;
+    public float jumpHeight = 7.0f;
 
     private float velX = 0;
     
 	void Start() {
         pm = gameObject.GetComponent<PlayerMovement>();
-	}
+    }
 
     public void Move(float moveX) {
-        var velX = Mathf.Max(-1, Mathf.Min(1, moveX)) * speed;
-        if (this.velX != velX) {
-            pm.MoveX(velX);
-            this.velX = velX;
+        float newX = Mathf.Max(-1, Mathf.Min(1, moveX)) * speed;
+
+        if (newX != this.velX) {
+            pm.MoveX(newX);
             if (NetCode.IsConnected) {
                 byte[] buffer = NetCode.BufferOp(OpCode.Move, 7);
-                Buffer.BlockCopy(BitConverter.GetBytes(velX), 0, buffer, 3, 4);
+                Buffer.BlockCopy(BitConverter.GetBytes(newX), 0, buffer, 3, 4);
                 NetCode.socket.Send(buffer, buffer.Length);
             }
+            this.velX = newX;
         }
     }
 
     public void Jump(float jumpMult = 1) {
-        var velY = jumpHeight * jumpMult;
+        float velY = jumpHeight * jumpMult;
         pm.Jump(velY);
 
         // Send to network

--- a/super-cool-game/Assets/Scripts/Player/PlayerInput.cs
+++ b/super-cool-game/Assets/Scripts/Player/PlayerInput.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 
 public class PlayerInput : MonoBehaviour {
     /* Handles user inputs, to be sent over to PlayerController */

--- a/super-cool-game/Assets/Scripts/Player/PlayerMovement.cs
+++ b/super-cool-game/Assets/Scripts/Player/PlayerMovement.cs
@@ -4,51 +4,67 @@ public class PlayerMovement : MonoBehaviour {
     /* Translates commands from PlayerController into movement */
 
     private Rigidbody2D rb;
-    private BoxCollider2D groundTrigger;
 
-    private float friction = 0.4f;
-    private float velX = 0, velY = 0;
+    public float ERROR_THRESHOLD = 0.2f;
+    private float velX = 0;
+    private float velY = 0;
+
+    private int excludePlayerMask;
 
     void Start() {
-        rb = GetComponent<Rigidbody2D>();
+        rb = gameObject.GetComponent<Rigidbody2D>();
+        excludePlayerMask = ~(1 << LayerMask.NameToLayer("Player"));
     }
 
     void FixedUpdate() {
+        // Apply gravity
         if (!IsGrounded) {
-            // Apply gravity
             velY -= 9.81f * 1.5f * Time.fixedDeltaTime;
+        } else if (velY < 0) {
+            velY = 0;
         }
+
+        // Prevent pushing other players
+        if (IsTouchingSides)
+            velX = 0;
+
         rb.velocity = new Vector2(velX, velY);
     }
 
-    public void Jump(float velY) {
+    public void Jump(float inputY) {
         if (IsGrounded)
-            this.velY = velY;
+            this.velY = inputY;
     }
 
     // Moves the player on the X axis
-    public void MoveX(float velX) {
-        this.velX = velX;
+    public void MoveX(float inputX) {
+        this.velX = inputX;
     }
 
-    public void MoveY(float velY) {
-        this.velY = velY;
+    public void AuthoritativeMove(Vector2 pos, Vector2 vel) {
+        var delta = (rb.position - pos).magnitude;
+        if (delta > ERROR_THRESHOLD) {
+            rb.position = pos;
+            rb.velocity = vel;
+            velX = vel.x;
+            velY = vel.y;
+        }
     }
 
     public bool IsGrounded {
         get { return touchingColliders > 0; }
-        private set { }
     }
 
-    private float ApplyFriction(float vel) {
-        if (!IsGrounded) return vel;
-
-        if (vel > 0)
-            vel = Mathf.Max(0, vel - friction);
-        else if (vel < 0)
-            vel = Mathf.Min(0, vel + friction);
-
-        return vel;
+    public bool IsTouchingSides {
+        get {
+            RaycastHit2D leftHit = Physics2D.Raycast(transform.position, Vector2.left, 0.32f, excludePlayerMask);
+            RaycastHit2D rightHit = Physics2D.Raycast(transform.position, Vector2.right, 0.32f, excludePlayerMask);
+            if ((velX < 0 && leftHit.collider != null) ||
+                 (velX > 0 && rightHit.collider != null)) {
+                return true;
+            }
+            return false;
+        }
     }
 
     private int touchingColliders = 0;

--- a/super-cool-game/ProjectSettings/DynamicsManager.asset
+++ b/super-cool-game/ProjectSettings/DynamicsManager.asset
@@ -4,7 +4,7 @@
 PhysicsManager:
   m_ObjectHideFlags: 0
   serializedVersion: 7
-  m_Gravity: {x: 0, y: -9.81, z: 0}
+  m_Gravity: {x: 0, y: 0, z: 0}
   m_DefaultMaterial: {fileID: 0}
   m_BounceThreshold: 2
   m_SleepThreshold: 0.005

--- a/super-cool-game/ProjectSettings/Physics2DSettings.asset
+++ b/super-cool-game/ProjectSettings/Physics2DSettings.asset
@@ -4,7 +4,7 @@
 Physics2DSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 3
-  m_Gravity: {x: 0, y: -9.81}
+  m_Gravity: {x: 0, y: 0}
   m_DefaultMaterial: {fileID: 0}
   m_VelocityIterations: 8
   m_PositionIterations: 3

--- a/super-cool-game/ProjectSettings/ProjectSettings.asset
+++ b/super-cool-game/ProjectSettings/ProjectSettings.asset
@@ -393,6 +393,7 @@ PlayerSettings:
   switchAllowsVideoCapturing: 1
   switchAllowsRuntimeAddOnContentInstall: 0
   switchDataLossConfirmation: 0
+  switchUserAccountLockEnabled: 0
   switchSupportedNpadStyles: 3
   switchNativeFsCacheSize: 32
   switchIsHoldTypeHorizontal: 0


### PR DESCRIPTION
 * Only correct local player's position if it differs from
   server's position by some set threshold
 * For the other players, always set their rigidbody's
   (and colliders) position to the server's, but lerp
   the sprite smoothly towards it's rigidbody's position.
 * Handle all network commands in Update() all together,
   except SetPos, which is handled one at the time in FixedUpdate()
 * Bug fixes!